### PR TITLE
creating a nodePort that will map to the mongodb port

### DIFF
--- a/kd/test/pttg-mongodb-svc.yaml
+++ b/kd/test/pttg-mongodb-svc.yaml
@@ -6,9 +6,11 @@ metadata:
     name: pttg-mongodb
   name: pttg-mongodb
 spec:
+  type: NodePort
   ports:
   - name: http
     port: 27017
+    nodePort: 30702
     targetPort: http
   selector:
     name: pttg-mongodb


### PR DESCRIPTION
This PR creates a nodePort to surface the mongodb port for internal loadbalancing.
